### PR TITLE
local fix for 1.15?

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,14 +15,23 @@ jobs:
             otp: '24.3'
 
           - elixir: '1.13'
-            otp: '24.2'
-          - elixir: '1.13'
             otp: '24.3'
           - elixir: '1.13'
             otp: '25.0'
 
           - elixir: '1.14'
+            otp: '24.3'
+          - elixir: '1.14'
             otp: '25.0'
+          - elixir: '1.14'
+            otp: '26.0'
+
+          - elixir: '1.15'
+            otp: '24.3'
+          - elixir: '1.15'
+            otp: '25.0'
+          - elixir: '1.15'
+            otp: '26.0'
 
     runs-on: ubuntu-latest
 

--- a/test/last_crusader/micropub/handler_test.exs
+++ b/test/last_crusader/micropub/handler_test.exs
@@ -31,7 +31,7 @@ defmodule LastCrusader.Micropub.MicropubHandlerTest do
              ]
 
       assert conn.resp_body ==
-               ~S({"syndicate-to":[{"name":"Twitter","uid":"https://twitter.com/some_twitter_account"}],"types":{"post-types":[{"name":"Note","type":"note"}]}})
+               ~S({"types":{"post-types":[{"name":"Note","type":"note"}]},"syndicate-to":[{"name":"Twitter","uid":"https://twitter.com/some_twitter_account"}]})
     end
 
     test "it should return syndication targets" do

--- a/test/last_crusader/micropub/hugo_test.exs
+++ b/test/last_crusader/micropub/hugo_test.exs
@@ -278,9 +278,9 @@ defmodule LastCrusader.HugoTest do
 
       assert file_content == """
              +++
+             date = "2015-01-24T00:50:07+01:00"
              bookmark = "http://some-url.com/"
              bookmarktags = ["one_tag"]
-             date = "2015-01-24T00:50:07+01:00"
              +++
              """
     end


### PR DESCRIPTION
strange behaviour on 2 tests on my local env with elixir 1.15

```
1) test Hugo.new/3 it should create bookmarks with special tags:  (LastCrusader.HugoTest)
     test/last_crusader/micropub/hugo_test.exs:272
     Assertion with == failed
     code:  assert file_content ==
              "+++\nbookmark = \"http://some-url.com/\"\nbookmarktags = [\"one_tag\"]\ndate = \"2015-01-24T00:50:07+01:00\"\n+++\n"
     left:  "+++\ndate = \"2015-01-24T00:50:07+01:00\"\nbookmark = \"http://some-url.com/\"\nbookmarktags = [\"one_tag\"]\n+++\n"
     right: "+++\nbookmark = \"http://some-url.com/\"\nbookmarktags = [\"one_tag\"]\ndate = \"2015-01-24T00:50:07+01:00\"\n+++\n"
     stacktrace:
       test/last_crusader/micropub/hugo_test.exs:279: (test)



  2) test config endpoint it should return supported types (LastCrusader.Micropub.MicropubHandlerTest)
     test/last_crusader/micropub/handler_test.exs:21
     Assertion with == failed
     code:  assert conn.resp_body ==
              ~S"{\"syndicate-to\":[{\"name\":\"Twitter\",\"uid\":\"https://twitter.com/some_twitter_account\"}],\"types\":{\"post-types\":[{\"name\":\"Note\",\"type\":\"note\"}]}}"
     left:  "{\"types\":{\"post-types\":[{\"name\":\"Note\",\"type\":\"note\"}]},\"syndicate-to\":[{\"name\":\"Twitter\",\"uid\":\"https://twitter.com/some_twitter_account\"}]}"
     right: "{\"syndicate-to\":[{\"name\":\"Twitter\",\"uid\":\"https://twitter.com/some_twitter_account\"}],\"types\":{\"post-types\":[{\"name\":\"Note\",\"type\":\"note\"}]}}"
     stacktrace:
       test/last_crusader/micropub/handler_test.exs:33: (test)


Finished in 0.05 seconds (0.04s async, 0.01s sync)
2 tests, 2 failures
```
